### PR TITLE
Fix: IO exeption when launch on TeamCity

### DIFF
--- a/src/LimeFlight.OpenAPI.Diff/Output/ConsoleRender.cs
+++ b/src/LimeFlight.OpenAPI.Diff/Output/ConsoleRender.cs
@@ -18,7 +18,28 @@ namespace LimeFlight.OpenAPI.Diff.Output
 
         private static ChangedOpenApiBO _diff;
 
+        private const int DefaultConsoleWidth = 80;
+
+        private static readonly int _consoleWidth = DefaultConsoleWidth;
+
         private StringBuilder _output;
+
+        static ConsoleRender()
+        {
+            try
+            {
+                _consoleWidth = Console.BufferWidth;
+            }
+            catch
+            {
+                // Console.BufferWidth(get) will throw exceptions in certain circumstances
+            }
+
+            if (_consoleWidth < 10) // Mono will return 0 instead of throwing an exception
+            {
+                _consoleWidth = DefaultConsoleWidth;
+            }
+        }
 
         public Task<string> Render(ChangedOpenApiBO diff)
         {
@@ -100,19 +121,19 @@ namespace LimeFlight.OpenAPI.Diff.Output
             var offset = little.Length * 2;
 
             return
-                $"{Separator(ch)}{little}{Center(title, -offset)}{little.PadLeft(Console.WindowWidth / 2 - title.Length / 2 + little.Length)}{Environment.NewLine}{Separator(ch)}";
+                $"{Separator(ch)}{little}{Center(title, -offset)}{little.PadLeft(_consoleWidth / 2 - title.Length / 2 + little.Length)}{Environment.NewLine}{Separator(ch)}";
         }
 
         private static StringBuilder Separator(char ch)
         {
             var sb = new StringBuilder();
-            return sb.Append(new string(ch, Console.WindowWidth))
+            return sb.Append(new string(ch, _consoleWidth))
                 .Append(Environment.NewLine);
         }
 
         private static string Center(string center, int offset = 0)
         {
-            return string.Format("{0," + (Console.WindowWidth / 2 + center.Length / 2 + offset) + "}", center);
+            return string.Format("{0," + (_consoleWidth / 2 + center.Length / 2 + offset) + "}", center);
         }
 
         private static string OlChanged(IReadOnlyCollection<ChangedOperationBO> operations)


### PR DESCRIPTION
We have an IO exception when rendering diff to the console when the utility is run in TeamCity.

This code fix it

```
Unhandled exception. System.IO.IOException: The handle is invalid.
     at System.ConsolePal.GetBufferInfo(Boolean throwOnNoConsole, Boolean& succeeded)
     at System.ConsolePal.get_WindowWidth()
     at System.Console.get_WindowWidth()
     at LimeFlight.OpenAPI.Diff.Output.ConsoleRender.Separator(Char ch) in \src\LimeFlight.OpenAPI.Diff\Output\ConsoleRender.cs:line 109
     at LimeFlight.OpenAPI.Diff.Output.ConsoleRender.Title(String title, Char ch) in <path>\src\LimeFlight.OpenAPI.Diff\Output\ConsoleRender.cs:line 102
     at LimeFlight.OpenAPI.Diff.Output.ConsoleRender.BigTitle(String title) in <path>\src\LimeFlight.OpenAPI.Diff\Output\ConsoleRender.cs:line 94
     at LimeFlight.OpenAPI.Diff.Output.ConsoleRender.Render(ChangedOpenApiBO diff) in <path>\src\LimeFlight.OpenAPI.Diff\Output\ConsoleRender.cs:line 33
     at LimeFlight.OpenAPI.Diff.CLI.Program.OnExecute() in <path>\src\LimeFlight.OpenAPI.Diff.CLI\Program.cs:line 79
     at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.InvokeAsync(MethodInfo method, Object instance, Object[] arguments)
     at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.OnExecute(ConventionContext context, CancellationToken cancellationToken)
     at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.<>c__DisplayClass0_0.<<Apply>b__0>d.MoveNext()
  --- End of stack trace from previous location where exception was thrown ---
     at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
     at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync[TApp](CommandLineContext context, CancellationToken cancellationToken)
     at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute[TApp](CommandLineContext context)
     at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute[TApp](IConsole console, String[] args)
     at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute[TApp](String[] args)
     at LimeFlight.OpenAPI.Diff.CLI.Program.Main(String[] args) in <path>\src\LimeFlight.OpenAPI.Diff.CLI\Program.cs:line 51
```